### PR TITLE
Recognises the ability to use reserved words in specific contexts

### DIFF
--- a/TokenReflection/Php/ReflectionConstant.php
+++ b/TokenReflection/Php/ReflectionConstant.php
@@ -310,7 +310,12 @@ class ReflectionConstant implements IReflection, TokenReflection\IReflectionCons
 	 */
 	public function getOriginalValueDefinition()
 	{
-		return token_get_all($this->getValueDefinition());
+		$valueDefinition = $this->getValueDefinition();
+		if (PHP_VERSION_ID >= 70000) {
+			return token_get_all($valueDefinition, TOKEN_PARSE);
+		}
+
+		return token_get_all($valueDefinition);
 	}
 
 	/**

--- a/TokenReflection/Stream/StreamBase.php
+++ b/TokenReflection/Stream/StreamBase.php
@@ -77,7 +77,12 @@ abstract class StreamBase implements SeekableIterator, Countable, ArrayAccess, S
 	 */
 	protected final function processSource($source)
 	{
-		$stream = @token_get_all(str_replace(array("\r\n", "\r"), "\n", $source));
+		$source = str_replace(array("\r\n", "\r"), "\n", $source);
+		if (PHP_VERSION_ID >= 70000) {
+			$stream = @token_get_all($source, TOKEN_PARSE);
+		} else {
+			$stream = @token_get_all($source);
+		}
 
 		static $checkLines = array(T_COMMENT => true, T_WHITESPACE => true, T_DOC_COMMENT => true, T_INLINE_HTML => true, T_ENCAPSED_AND_WHITESPACE => true, T_CONSTANT_ENCAPSED_STRING => true);
 


### PR DESCRIPTION
This fixes parsing in cases where the class constant is used on a class
name:
MyClass::class