### PR TITLE
Replace continue with break in switch block

### DIFF
--- a/TokenReflection/ReflectionFileNamespace.php
+++ b/TokenReflection/ReflectionFileNamespace.php
@@ -385,7 +385,7 @@ class ReflectionFileNamespace extends ReflectionElement
 							->findMatchingBracket()
 							->next();
 
-						continue;
+						break;
 					}
 
 					$function = new ReflectionFunction($tokenStream, $this->getBroker(), $this);


### PR DESCRIPTION
With php7.3 this throw a warning:
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? 